### PR TITLE
Feature:  customizable tape names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 .nyc_output
+new-tapes/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Returns an unstarted talkback server instance.
 | **https** | `Object` | HTTPS server [options](#https-options) | [Defaults](#https-options) |
 | **record** | `Boolean` | Enable record of unknown requests to tapes | `true` |
 | **name** | `String` | Server name | Defaults to `host` value |
+| **tapeNameGenerator** | `Function` | Customize how a tape name is generated for new tapes. | `null` |
 | **ignoreHeaders** | `[String]` | List of headers to ignore when matching tapes. Useful when having dynamic headers like cookies or correlation ids | `['content-length', 'host]` |
 | **ignoreQueryParams** | `[String]` | List of query params to ignore when matching tapes. Useful when having dynamic query params like timestamps| `[]` |
 | **ignoreBody** | `Boolean` | Should the request body be ignored when matching tapes | `false` |
@@ -88,7 +89,20 @@ Since tapes are only loaded on startup, any changes to a tape requires a server 
 
 #### File Name
 New tapes will be created under the `path` directory with the name `unnamed-n.json5`, where `n` is the tape number.   
-Tapes can be renamed at will, for example to give some meaning to the scenario the tape represents.
+Tapes can be renamed at will, for example to give some meaning to the scenario the tape represents.  
+If a custom `tapeNameGenerator` is provided, it will be called to produce an alternate file path under `path`
+that can be based on the tape contents.  Note that the file extension `.json5` will be appended automatically.
+
+##### Example:
+```javascript
+function nameGenerator(tapeNumber, tape) {
+  // organize in folders by request method
+  // e.g. tapes/GET/unnamed-1.json5
+  //      tapes/GET/unnamed-3.json5
+  //      tapes/POST/unnamed-2.json5
+  return path.join(`${tape.req.method}`, `unnamed-${tapeNumber}`)
+}
+```
 
 #### Request and Response body
 If the content type of the request or response is considered _human readable_ and _uncompressed_, the body will be saved in plain text.      

--- a/dist/README.md
+++ b/dist/README.md
@@ -49,6 +49,7 @@ Returns an unstarted talkback server instance.
 | **https** | `Object` | HTTPS server [options](#https-options) | [Defaults](#https-options) |
 | **record** | `Boolean` | Enable record of unknown requests to tapes | `true` |
 | **name** | `String` | Server name | Defaults to `host` value |
+| **tapeNameGenerator** | `Function` | Customize how a tape name is generated for new tapes. | `null` |
 | **ignoreHeaders** | `[String]` | List of headers to ignore when matching tapes. Useful when having dynamic headers like cookies or correlation ids | `['content-length', 'host]` |
 | **ignoreQueryParams** | `[String]` | List of query params to ignore when matching tapes. Useful when having dynamic query params like timestamps| `[]` |
 | **ignoreBody** | `Boolean` | Should the request body be ignored when matching tapes | `false` |
@@ -88,7 +89,20 @@ Since tapes are only loaded on startup, any changes to a tape requires a server 
 
 #### File Name
 New tapes will be created under the `path` directory with the name `unnamed-n.json5`, where `n` is the tape number.   
-Tapes can be renamed at will, for example to give some meaning to the scenario the tape represents.
+Tapes can be renamed at will, for example to give some meaning to the scenario the tape represents.  
+If a custom `tapeNameGenerator` is provided, it will be called to produce an alternate file path under `path`
+that can be based on the tape contents.  Note that the file extension `.json5` will be appended automatically.
+
+##### Example:
+```javascript
+function nameGenerator(tapeNumber, tape) {
+  // organize in folders by request method
+  // e.g. tapes/GET/unnamed-1.json5
+  //      tapes/GET/unnamed-3.json5
+  //      tapes/POST/unnamed-2.json5
+  return path.join(`${tape.req.method}`, `unnamed-${tapeNumber}`)
+}
+```
 
 #### Request and Response body
 If the content type of the request or response is considered _human readable_ and _uncompressed_, the body will be saved in plain text.      

--- a/dist/index.js
+++ b/dist/index.js
@@ -667,9 +667,8 @@ function () {
       tape.used = true;
       this.tapes.push(tape);
       var toSave = new TapeRenderer(tape).render();
-      var tapeName = "unnamed-".concat(this.currentTapeId(), ".json5");
-      tape.path = tapeName;
-      var filename = this.path + tapeName;
+      var filename = this.createTapePath(tape);
+      tape.path = path.basename(filename);
       this.options.logger.log("Saving request ".concat(tape.req.url, " at ").concat(filename));
       fs.writeFileSync(filename, JSON5.stringify(toSave, null, 4));
     }
@@ -691,6 +690,26 @@ function () {
       return this.tapes.forEach(function (t) {
         return t.used = false;
       });
+    }
+  }, {
+    key: "createTapePath",
+    value: function createTapePath(tape) {
+      var currentTapeId = this.currentTapeId();
+      var tapePath = "unnamed-".concat(currentTapeId, ".json5");
+
+      if (this.options.tapeNameGenerator) {
+        tapePath = this.options.tapeNameGenerator(currentTapeId, tape);
+      }
+
+      var result = path.normalize(path.join(this.options.path, tapePath));
+
+      if (!result.endsWith(".json5")) {
+        result = "".concat(result, ".json5");
+      }
+
+      var dir = path.dirname(result);
+      mkdirp.sync(dir);
+      return result;
     }
   }]);
 
@@ -757,7 +776,7 @@ function () {
                 return _context.stop();
             }
           }
-        }, _callee, this, [[0, 11]]);
+        }, _callee, null, [[0, 11]]);
       })));
     }
   }, {
@@ -855,6 +874,7 @@ var defaultOptions = {
   path: "./tapes/",
   record: true,
   name: "unnamed",
+  tapeNameGenerator: null,
   https: {
     enabled: false,
     keyPath: null,

--- a/src/options.js
+++ b/src/options.js
@@ -5,6 +5,7 @@ const defaultOptions = {
   path: "./tapes/",
   record: true,
   name: "unnamed",
+  tapeNameGenerator: null,
 
   https: {
     enabled: false,

--- a/src/tape-store.js
+++ b/src/tape-store.js
@@ -57,9 +57,8 @@ export default class TapeStore {
 
     const toSave = new TapeRenderer(tape).render()
 
-    const tapeName = `unnamed-${this.currentTapeId()}.json5`
-    tape.path = tapeName
-    const filename = this.path + tapeName
+    const filename = this.createTapePath(tape)
+    tape.path = path.basename(filename)
     this.options.logger.log(`Saving request ${tape.req.url} at ${filename}`)
     fs.writeFileSync(filename, JSON5.stringify(toSave, null, 4))
   }
@@ -74,5 +73,21 @@ export default class TapeStore {
 
   resetTapeUsage() {
     return this.tapes.forEach(t => t.used = false)
+  }
+
+  createTapePath(tape) {
+    const currentTapeId = this.currentTapeId()
+    let tapePath = `unnamed-${currentTapeId}.json5`
+    if (this.options.tapeNameGenerator) {
+      tapePath = this.options.tapeNameGenerator(currentTapeId, tape)
+    }
+    let result = path.normalize(path.join(this.options.path, tapePath))
+    if (!result.endsWith(".json5")) {
+      result = `${result}.json5`
+    }
+    const dir = path.dirname(result)
+    mkdirp.sync(dir)
+
+    return result
   }
 }


### PR DESCRIPTION
I thought this would be a handy feature in a test suite that had a wide variety of HTTP calls; allowing caller to custom-organize the new tapes based on the request would help them sort out requests that might need de-duplication.

Defaults to the standard `unnamed-${tapeNumber}` scheme, so backwards-compatible.  Also included a unit test, and updated README.

Let me know what you think!  Happy to implement feedback, more tests/checking, etc.