### PR TITLE
Fixed malformed data from utf-8 JSON Content-Length

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -151,7 +151,7 @@ function () {
           var json = JSON.stringify(reqResObj.body, null, 2);
 
           if (Headers.read(reqResObj.headers, "content-length")) {
-            Headers.write(reqResObj.headers, "content-length", json.length, metaPrefix);
+            Headers.write(reqResObj.headers, "content-length", Buffer.byteLength(json), metaPrefix);
           }
 
           return bufferShim.from(json);

--- a/src/tape-renderer.js
+++ b/src/tape-renderer.js
@@ -30,7 +30,7 @@ export default class TapeRenderer {
       if (isResAnObject && mediaType.isJSON()) {
         const json = JSON.stringify(reqResObj.body, null, 2)
         if (Headers.read(reqResObj.headers, "content-length")) {
-          Headers.write(reqResObj.headers, "content-length", json.length, metaPrefix)
+          Headers.write(reqResObj.headers, "content-length", Buffer.byteLength(json), metaPrefix)
         }
         return bufferShim.from(json)
       } else {

--- a/test/tape-renderer.spec.js
+++ b/test/tape-renderer.spec.js
@@ -104,7 +104,7 @@ describe("TapeRenderer", () => {
           headers: {
             ...raw.res.headers,
             "content-type": ["application/json"],
-            "content-length": [68]
+            "content-length": [20]
           },
           body: {
             foo: "bar",

--- a/test/tape-renderer.spec.js
+++ b/test/tape-renderer.spec.js
@@ -104,10 +104,11 @@ describe("TapeRenderer", () => {
           headers: {
             ...raw.res.headers,
             "content-type": ["application/json"],
-            "content-length": [20]
+            "content-length": [68]
           },
           body: {
             foo: "bar",
+            utf8: "🔤",
             nested: {
               fuu: 3
             }
@@ -119,7 +120,7 @@ describe("TapeRenderer", () => {
       expect(tape.req.body).to.eql(Buffer.from(JSON.stringify(newRaw.req.body, null, 2)))
 
       expect(tape.res.body).to.eql(Buffer.from(JSON.stringify(newRaw.res.body, null, 2)))
-      expect(tape.res.headers["content-length"]).to.eql([50])
+      expect(tape.res.headers["content-length"]).to.eql([68])
 
       delete newRaw.res.headers["content-length"]
       tape = TapeRenderer.fromStore(newRaw, opts)


### PR DESCRIPTION
Closes #23

When `content-length` is set in the proxied response headers and the JSON body contains utf-8 characters the `content-length` send back to the client is incorrectly calculated (as `json.length` does not count the extra bits in a utf-8 characters).

This PR fixes the the `content-length` calculation for JSON responses and sends back the correct `byteLength` to clients. For more examples see #23.