### PR TITLE
docs: use close() top stop the talkback server

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See all [Options](#options).
 const talkback = talkback(options)
 
 talkback.start(() => console.log("Talkback Started"))
-talkback.stop()
+talkback.close()
 ```
 
 #### talkback.requestHandler(options: Partial\<Options\>): Promise\<RequestHandler\>


### PR DESCRIPTION
Minor docs update.

As Talkback server is an instance of [`http.Server` ](https://nodejs.org/api/http.html#http_server_close_callback) you need to use `close()` to stop it.