### PR TITLE
fix: handle invalid JSON response

### DIFF
--- a/src/tape-renderer.ts
+++ b/src/tape-renderer.ts
@@ -98,7 +98,11 @@ export default class TapeRenderer {
       const rawBody = body.toString("utf8")
 
       if (mediaType.isJSON()) {
-        return JSON.parse(rawBody)
+        try {
+          return JSON.parse(rawBody);
+        } catch {
+          return rawBody;
+        }
       } else {
         return rawBody
       }

--- a/test/tape-renderer.spec.ts
+++ b/test/tape-renderer.spec.ts
@@ -186,6 +186,36 @@ describe("TapeRenderer", () => {
       expect(await tapeRenderer.render()).to.eql(newRaw)
     })
 
+    it("renders invalid json response as text", async () => {
+      const newRaw = {
+        ...raw,
+        meta: {
+          ...raw.meta,
+          resHumanReadable: true
+        },
+        req: {
+          ...raw.req,
+          headers: {
+            ...raw.req.headers
+          }
+        },
+        res: {
+          ...raw.res,
+          headers: {
+            ...raw.res.headers,
+            "content-type": ["application/json"],
+            "content-length": [20]
+          },
+          body: "I said I was going to send JSON, but actually I've changed my mind and here's some text"
+        }
+      }
+      const newTape = await TapeRenderer.fromStore(newRaw, opts)
+
+      delete newRaw.req.headers["x-ignored"]
+      const tapeRenderer = new TapeRenderer(newTape)
+      expect(await tapeRenderer.render()).to.eql(newRaw)
+    })
+
     it("renders tapes with empty bodies", async () => {
       const newRaw = {
         ...raw,


### PR DESCRIPTION
Sometimes a server will respond with a `"content-type": "application/json"` header, but sends text or invalid JSON in the body.

In this case I was receiving an error from talkback:
`Error handling request SyntaxError: Unexpected token e in JSON at position 0`

This PR tries to parse the response as JSON first, if it fails fallback to the `rawBody`.