### PR TITLE
fix: identify amz-json types as human-readable

### DIFF
--- a/src/utils/media-type.ts
+++ b/src/utils/media-type.ts
@@ -7,6 +7,8 @@ const equals = (to: string) => (contentType: string) => to == contentType
 
 export const jsonTypes = [
   equals("application/json"),
+  equals("application/x-amz-json-1.0"),
+  equals("application/x-amz-json-1.1"),
   (contentType: string) => contentType.startsWith("application/") && contentType.endsWith("+json")
 ]
 


### PR DESCRIPTION
These curious content-types are specific to aws and seem to be identical to application/json for all practical purposes (they are human readable). Having these request content types resolve as human readable would be greatly helpful for my use case. I can re-write this to be a lambda that ignores the specific version if you prefer. These are the only two versions in existence.