### PR TITLE
Add support for brotli

### DIFF
--- a/src/utils/content-encoding.ts
+++ b/src/utils/content-encoding.ts
@@ -5,7 +5,8 @@ import Headers from "./headers"
 
 const ALGORITHMS = {
   gzip: {compress: zlib.gzipSync, uncompress: zlib.gunzipSync},
-  deflate: {compress: zlib.deflateSync, uncompress: zlib.inflateSync}
+  deflate: {compress: zlib.deflateSync, uncompress: zlib.inflateSync},
+  br: {compress: zlib.brotliCompressSync, uncompress: zlib.brotliDecompressSync}
 }
 
 type SupportedAlgorithms = keyof typeof ALGORITHMS


### PR DESCRIPTION
Adds support for compressing and decompressing brotli. Node's `zlib` module has had support for brotli compression and decompression since v10.6: https://nodejs.org/api/zlib.html#class-zlibbrotlicompress

We've been using (and enjoying) talkback over in https://github.com/wordpress/openverse-frontend and I ran into this recently with our upstream server being fronted by cloudflare which is using brotli compression.