### PR TITLE
Allow Req redirect follow instead of manual

### DIFF
--- a/src/request-handler.ts
+++ b/src/request-handler.ts
@@ -122,7 +122,7 @@ export default class RequestHandler {
 
   private async makeRealRequest(req: HttpRequest) {
     let fetchBody: Buffer | null
-    let {method, url, body} = req
+    let {method, url, body, redirect='manual'} = req
     fetchBody = body
     const headers = {...req.headers}
     delete headers.host
@@ -134,7 +134,7 @@ export default class RequestHandler {
       fetchBody = null
     }
 
-    const fRes = await fetch(host + url, {method, headers, body: fetchBody, compress: false, redirect: "manual"})
+    const fRes = await fetch(host + url, {method, headers, body: fetchBody, compress: false, redirect})
     const buff = await fRes.buffer()
     return {
       status: fRes.status,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,10 @@ export interface ReqRes {
 }
 
 export interface Req extends ReqRes {
-  url: string,
+  url: string
   method: string
+  /** Uses 'manual' by default */
+  redirect?: "manual" | "follow" | "error"
 }
 
 export type HttpRequest = Req


### PR DESCRIPTION
The default for a request has been to pass in redirect manual to fetch when doing real requests. This is sometimes problematic for an API that responds with a redirect to another url with the actual content that a tape should contain instead. With this change the redirect property can be changed to redirect follow (which is the normal default for fetch).

Usage:

```typescript
const request = { url, method, body, headers, redirect: 'follow' }
requestHandler.handle(request)
```