### PR TITLE
Cleanly exit (child) process when receiving a signal

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -97,5 +97,7 @@ export default class TalkbackServer {
       const summary = new Summary(this.tapeStore.tapes, this.options)
       summary.print()
     }
+
+    process.exit(0)
   }
 }


### PR DESCRIPTION
This is especially important when the talkback server is started as a child process, e.g. via `tsx watch`. Then the parent process will wait for the `exit` callback, see https://github.com/privatenumber/tsx/blob/50d81944b1a2ced81f0c4a575f18df340d56ec38/src/watch/index.ts#L122 for example.