### PR TITLE
fix: implement workaround for issue [#91]

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const response = await talkbackHandler.handle(httpRequest)
 | **record** | `String \| Function` | Set record mode. [More info](#recording-modes) | `RecordMode.NEW` |
 | **fallbackMode** | `String \| Function` | Fallback mode for unknown requests when recording is disabled. [More info](#recording-modes) | `FallbackMode.NOT_FOUND` |
 | **name** | `String` | Server name | Defaults to `host` value |
+| **numberedTapes** | `Boolean` | Whether to use incrementing numbers for default tape naming or not [More info](#file-name) | `true` |
 | **tapeNameGenerator** | `Function` | [Customize](#file-name) how a tape name is generated for new tapes. | `null` |
 | **allowHeaders** | `[String]` | List of headers to include when matching tapes. If present, headers that are not part of the list will be ignored. By default, most headers are considered (See `ignoreHeaders`)</br></br>Setting this value to `[]` will disable header matching on tapes.</br>Note that `content-type` and `content-encoding` are needed to decode the body into plain-text. [More info](#request-and-response-body)  | `null` |
 | **ignoreHeaders** | `[String]` | List of headers to ignore when matching tapes. By default, most headers are considered | `['content-length', 'host']` |
@@ -148,7 +149,10 @@ If the request or response have a JSON *content-type*, their body will be pretty
 This means differences in formatting are ignored when comparing tapes, and any special formatting in the response will be lost.
 
 #### File Name
-New tapes will be created under the `path` directory with the name `unnamed-n.json5`, where `n` is the tape number.   
+By default new tapes will be created under the `path` directory with the name `unnamed-<n>.json5`, where `<n>` is the tape number.
+
+If you set the option `numberedTapes` to `false` the tapes will instead be named `unnamed-<slug>.json5`, where `<slug>` is a base 36 encoding the timestamp when the tape was created. Example: a tape created at `2020-02-01T11:02:15.130Z` would be named `unnamed-k63hll5m.json5`. This string will be in alphabetically ascending order. It is recommended to set `numberedTapes` to `false` to avoid tapes getting overwritten in some cases (issue[#91](https://github.com/ijpiantanida/talkback/issues/91)).
+
 Tapes can be renamed at will, for example to give some meaning to the scenario the tape represents.  
 If a custom `tapeNameGenerator` is provided, it will be called to produce an alternate file path under `path` that can be based on the tape contents. Note that the file extension `.json5` will be appended automatically.
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -23,6 +23,7 @@ export interface Options {
   record: string | ((req: Req) => string),
   fallbackMode: string | ((req: Req) => string),
   name: string,
+  numberedTapes: boolean,
   tapeNameGenerator?: (tapeNumber: number, tape: Tape) => string,
   https: {
     enabled: boolean,
@@ -56,6 +57,7 @@ export const DefaultOptions: Options = {
   record: RecordMode.NEW,
   fallbackMode: FallbackMode.NOT_FOUND,
   name: "unnamed server",
+  numberedTapes: true,
   tapeNameGenerator: undefined,
 
   https: {

--- a/src/tape-store.ts
+++ b/src/tape-store.ts
@@ -89,8 +89,16 @@ export default class TapeStore {
     fs.writeFileSync(fullFilename, JSON5.stringify(toSave, null, 4))
   }
 
-  currentTapeId() {
+  currentTapeNumber() {
     return this.tapes.length
+  }
+
+  currentTapeTimestampId(date: Date) {
+    return date.getTime().toString(36)
+  }
+
+  currentTapeId(tape?: Tape) {
+    return this.options.numberedTapes ? this.currentTapeNumber() : this.currentTapeTimestampId(tape?.meta.createdAt || new Date())
   }
 
   hasTapeBeenUsed(tapeName: string) {
@@ -102,10 +110,10 @@ export default class TapeStore {
   }
 
   createTapePath(tape: Tape) {
-    const currentTapeId = this.currentTapeId()
+    const currentTapeId = this.currentTapeId(tape)
     let tapePath = `unnamed-${currentTapeId}.json5`
     if (this.options.tapeNameGenerator) {
-      tapePath = this.options.tapeNameGenerator(currentTapeId, tape)
+      tapePath = this.options.tapeNameGenerator(this.currentTapeNumber(), tape)
     }
     let result = path.normalize(path.join(this.options.path, tapePath))
     if (!result.endsWith(".json5")) {

--- a/test/integration/talkback-server.spec.ts
+++ b/test/integration/talkback-server.spec.ts
@@ -65,7 +65,7 @@ const startTalkback = async (opts?: Partial<Options>) => {
   const talkbackServer = talkback(fullOptions(opts))
   await talkbackServer.start()
 
-  currentTapeId = talkbackServer.tapeStore.currentTapeId() + 1
+  currentTapeId = talkbackServer.tapeStore.currentTapeNumber() + 1
   return talkbackServer
 }
 


### PR DESCRIPTION
Allow for the talkback server to be started with `{ numberedTapes: false }` to get safer tape storage that is still in order of tape creation. 

Fix for #91 